### PR TITLE
era5cli v1.4.0: update meta.yml w/ grayskull

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @zklaus
+* @BSchilperoort @zklaus

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-About era5cli
-=============
+About era5cli-feedstock
+=======================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/era5cli-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/ewatercycle/era5cli
 
 Package license: Apache-2.0
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/era5cli-feedstock/blob/main/LICENSE.txt)
-
-Summary: A command line interface to download ERA5 data from the Copernicus Climate Data Store https://climate.copernicus.eu/.
+Summary: A command line interface to download ERA5 data from the Copernicus Climate Data Store. https://climate.copernicus.eu/..
 
 Current build status
 ====================
@@ -143,5 +143,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@BSchilperoort](https://github.com/BSchilperoort/)
 * [@zklaus](https://github.com/zklaus/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,49 +1,51 @@
 {% set name = "era5cli" %}
-{% set version = "1.3.2" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/era5cli-{{ version }}.tar.gz
-    sha256: 8d64e0f95c857ccbcd7c5cefe3604e3a8a16642b3e6f16ac61019f9005f7fe0a
-    patches:
-      - 0001-Remove-reading-of-CHANGELOG.rst-from-setup.py.patch
-  - path: requirements.txt
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/era5cli-{{ version }}.tar.gz
+  sha256: 60fbe777ccc565c553b67fb0c4157b8c6685e024fdf1dc65504a465ffde50fff
 
 build:
-  noarch: python
   entry_points:
     - era5cli = era5cli.cli:main
+  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:
   host:
+    - python >=3.7
+    - hatchling >=1.8.0
+    - hatch-vcs
+    - hatch-fancy-pypi-readme
     - pip
-    - python >=3.6
   run:
-    - cdsapi ==0.4.0
-    - netcdf4
+    - python >=3.7
+    - cdsapi ==0.5.1
     - pathos
     - ptable
-    - python >=3.6
+    - netcdf4
 
 test:
   imports:
     - era5cli
   commands:
     - pip check
+    - era5cli --help
   requires:
     - pip
 
 about:
   home: https://github.com/ewatercycle/era5cli
-  summary: A command line interface to download ERA5 data from the Copernicus Climate Data Store https://climate.copernicus.eu/.
+  summary: A command line interface to download ERA5 data from the Copernicus Climate Data Store. https://climate.copernicus.eu/..
   license: Apache-2.0
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - zklaus
+    - BSchilperoort


### PR DESCRIPTION
The built was broken because we changed to a pyproject.toml based setup.

As I am currently the main maintainer of era5cli, I have added myself as a maintainer of this recipe.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


